### PR TITLE
Enable FP16 TensorRT inference

### DIFF
--- a/rope/EngineBuilder.py
+++ b/rope/EngineBuilder.py
@@ -43,8 +43,13 @@ class EngineBuilder:
         # Costruisce il builder di TensorRT e la configurazione usando lo stesso logger
         self.builder = trt.Builder(TRT_LOGGER)
         self.config = self.builder.create_builder_config()
-        # Imposta il limite di memoria del pool di lavoro a 3 GB
-        self.config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 3 * (2 ** 30))  # 3 GB
+        # Imposta il limite di memoria del pool di lavoro a 8 GB
+        # Un workspace più ampio consente una maggiore libertà al motore di
+        # ottimizzare l'esecuzione, specialmente su GPU con molta memoria come
+        # la RTX 4090
+        self.config.set_memory_pool_limit(
+            trt.MemoryPoolType.WORKSPACE, 8 * (2 ** 30)
+        )  # 8 GB
 
         # Crea un profilo di ottimizzazione, se necessario
         profile = self.builder.create_optimization_profile()

--- a/rope/Models.py
+++ b/rope/Models.py
@@ -40,7 +40,9 @@ class Models():
         self.provider_name = 'CUDA'
         self.device = device
         self.trt_ep_options = {
-            'trt_max_workspace_size': 3 << 30,  # Dimensione massima dello spazio di lavoro in bytes
+            # Aumenta il workspace di TensorRT a 8 GB per consentire
+            # build più ottimizzate quando si utilizzano GPU con ampia VRAM
+            'trt_max_workspace_size': 8 << 30,
             'trt_engine_cache_enable': True,
             'trt_engine_cache_path': "tensorrt-engines",
             'trt_timing_cache_enable': True,

--- a/rope/TensorRTPredictor.py
+++ b/rope/TensorRTPredictor.py
@@ -185,7 +185,12 @@ class TensorRTPredictor:
             self.adjust_buffer(feed_dict, context)
 
             for name, tensor in self.tensors.items():
-                assert tensor.dtype == torch.float32, f"Tensor '{name}' should be torch.float32 but is {tensor.dtype}"
+                # Gli engine possono essere generati in FP16 o FP32. Consenti
+                # entrambe le opzioni verificando che il tensore sia in uno dei
+                # due formati supportati.
+                assert tensor.dtype in (torch.float32, torch.float16), (
+                    f"Tensor '{name}' should be fp32 or fp16 but is {tensor.dtype}"
+                )
                 context.set_tensor_address(name, tensor.data_ptr())
 
             nvtx.range_pop()
@@ -224,7 +229,10 @@ class TensorRTPredictor:
             self.adjust_buffer(feed_dict, context)
 
             for name, tensor in self.tensors.items():
-                assert tensor.dtype == torch.float32, f"Tensor '{name}' should be torch.float32 but is {tensor.dtype}"
+                # Supporta motori in FP16 o FP32 senza forzare un formato unico
+                assert tensor.dtype in (torch.float32, torch.float16), (
+                    f"Tensor '{name}' should be fp32 or fp16 but is {tensor.dtype}"
+                )
                 context.set_tensor_address(name, tensor.data_ptr())
 
             nvtx.range_pop()


### PR DESCRIPTION
## Summary
- enlarge TensorRT workspace memory to 8 GB
- expose larger workspace in onnxruntime settings
- allow FP16 tensors in TensorRT predictor

## Testing
- `python -m py_compile rope/TensorRTPredictor.py rope/EngineBuilder.py rope/Models.py`

------
https://chatgpt.com/codex/tasks/task_e_68640dc0efec8320a5c3556d1d0d61c5