### PR TITLE
Fix dangling threads in VideoManager

### DIFF
--- a/rope/Coordinator.py
+++ b/rope/Coordinator.py
@@ -12,7 +12,7 @@ resize_delay = 1
 mem_delay = 1
 
 def quit_app():
-    vm.terminate_audio_process_tree()
+    vm.cleanup()
     gui.destroy()
 
 # @profile

--- a/rope/VideoManager.py
+++ b/rope/VideoManager.py
@@ -129,6 +129,38 @@ class VideoManager():
         # Face Editor
         self.face_editor = []
 
+    def cleanup(self):
+        """Release resources and ensure all threads are closed."""
+        # Stop any ongoing playback which also joins worker threads
+        if self.play:
+            try:
+                self.play_video("stop")
+            except Exception:
+                pass
+
+        # Shut down thread pool if still active
+        if self.executor:
+            try:
+                self.executor.shutdown(wait=True)
+            finally:
+                self.executor = None
+
+        # Terminate any running audio process
+        self.terminate_audio_process_tree()
+
+        # Release video capture
+        if self.capture:
+            try:
+                self.capture.release()
+            finally:
+                self.capture = []
+
+        # Disable virtual camera if active
+        self.disable_virtualcam()
+
+    def __del__(self):
+        self.cleanup()
+
     def assign_found_faces(self, found_faces):
         self.found_faces = found_faces
 


### PR DESCRIPTION
## Summary
- ensure VideoManager cleans up the thread pool and other resources
- invoke cleanup when closing the GUI

## Testing
- `python -m py_compile rope/VideoManager.py rope/Coordinator.py`
- `python -m py_compile rope/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68640559c218832095bb096825a7e4ff